### PR TITLE
Feature v0.6 limit results

### DIFF
--- a/extras/addon_limit_results.js
+++ b/extras/addon_limit_results.js
@@ -23,16 +23,18 @@
 	
 */
 
-var intPartiesShowAtEnd = 5;
+var intPartiesShowAtEnd = 3;
 
 
 // 2.) Text für Buttons
 // Text on buttons
-var TEXT_RESULTS_BUTTON_SHOW_MORE = "Weitere Ergebnisse zeigen"
+var TEXT_RESULTS_BUTTON_SHOW_MORE = "Weitere Ergebnisse zeigen (von "+intParties+")"
 var TEXT_RESULTS_BUTTON_SHOW_LESS = "Weniger Ergebnisse zeigen"
+
 
 // 3.) In der DEFINITION.JS in den Erweiterten Einstellungen das Add-On eintragen.
 // Add the add-on to the advanced settings in DEFINITION.JS
+
 
 // 4.) Fertig. 
 // That's it.
@@ -73,107 +75,234 @@ function mow_addon_limit_results__MutationObserver() {
 }
 
 
-// Buttons in Addon-DIV in INDEX.HTML schreiben
+
+// Buttons in INDEX.HTML schreiben
+// Write buttons into INDEX.HTML
 function mow_addon_limit_results_create_buttons() {
 
-	// alten Inhalt (jedes Mal) löschen
-	$("#resultsAddonBottom").empty()
+	/* id "#resultsHeading" wird in fnStart() am Anfang geleert (empty()).
+	   -> mutationObserver erkennt Änderung und aktiviert diese Funktion :(
+	   -> prüfen, ob Inhalt in DIV existiert 
+	   
+	   id "#resultsHeading" is beeing emptied in fnStart() at the beginning
+	   -> mutationObserver checks for changes and activates this function 
+	   -> check if there's any content in the DIV 
+	 */
 
-	// id "#resultsHeading" wird in fnStart() am Anfang geleert (empty()).
-	// -> mutationObserver erkennt Änderung und aktiviert diese Funktion :(
-	// -> prüfen, ob Inhalt in DIV existiert 
-	resultsHeadingContent = $("#resultsHeading").text()
+	// resultsHeadingContent = $("#resultsHeading").text()
+	resultsHeadingContent = document.getElementById("resultsHeading").innerText
 
 	if (!resultsHeadingContent) {
 		// nix. Noch keine Ergebnisse im DIV
+		// Nothing writting in the results-DIV 
 	}
-	// schreibe Buttons
-	else {
-		divContent =  '<div id="Buttons_showPartiesAtEnd_resultsShort" class="row">'
+	// schreibe Buttons (einmalig)
+	// write the buttons (one time)
+	else {	
+
+		// Inhalt der Buttons 
+		// Content of buttons
+
+		buttonContent_Minus = '<button type="button" class="Buttons_showPartiesAtEnd_minus btn btn-outline-dark btn-sm btn-block" onclick="fnCalculate_Minus(0,0)">'+TEXT_RESULTS_BUTTON_SHOW_LESS+'</button>'
+		buttonContent_Plus  = '<button type="button" class="Buttons_showPartiesAtEnd_plus  btn btn-outline-dark btn-sm btn-block"  onclick="fnCalculate_Plus(0,0)">'+TEXT_RESULTS_BUTTON_SHOW_MORE+'</button>'
 		
-		divContent += '	<div class="col-1 col-md-6">'
-		divContent += '	</div>'
-						
-		divContent += '	<div class="col-5 col-md-3">'
-//		divContent += '		<button type="button" id="Buttons_showPartiesAtEnd_resultsShort_minus" class="btn btn-outline-dark btn-sm btn-block" onclick="">'+TEXT_RESULTS_BUTTON_SHOW_LESS+'</button>'
-		divContent += '	</div>'
-
-		divContent += '	<div class="col-5 col-md-3">'
-		divContent += '		<button type="button" id="Buttons_showPartiesAtEnd_resultsShort_plus" class="btn btn-outline-dark btn-sm btn-block" onclick="fnShowOnlyIntPartiesAtEnd_Plus(0, 0)">'+TEXT_RESULTS_BUTTON_SHOW_MORE+'</button>'
-		divContent += '	</div>'
+		// Erstelle eine neue Zeile mit Bootstrap-Klassen 
+		// -> 1. ROW -> 2a.) COL (links / left) + 2b.) COL (rechts / right)
+		// Create a new line with Bootstrap-classes 
 		
-		divContent += '</div>`'
+		// A. obere Tabelle / upper list - resultsShortTable
+		// 1. ROW
+		var element_resultsShortTable_col = document.getElementById("resultsShortTable").getElementsByClassName("col")[0]
+		var div_element = document.createElement('div');
+		resultsShortTable_col_row = element_resultsShortTable_col.appendChild(div_element)
+		resultsShortTable_col_row.className = "row"
+		
+		// 2a COL left
+		var div_element = document.createElement('div');
+		resultsShortTable_col_row_col_left = resultsShortTable_col_row.appendChild(div_element)
+		resultsShortTable_col_row_col_left.className = "col"
+		resultsShortTable_col_row_col_left.innerHTML = buttonContent_Minus
 
-		$("#resultsAddonBottom").append(divContent).fadeIn(750); 
+		// 2b COL right
+		var div_element = document.createElement('div');
+		resultsShortTable_col_row_col_right = resultsShortTable_col_row.appendChild(div_element)
+		resultsShortTable_col_row_col_right.className = "col text-center"
+		resultsShortTable_col_row_col_right.innerHTML = buttonContent_Plus
 
-		fnShowOnlyIntPartiesAtEnd_Plus(0, 0)
+		
+		// B. linke Tabelle / left list - resultsByThesis
+		// 1. ROW		
+		var element_resultsByThesisTable_col = document.getElementById("resultsByThesisTable").getElementsByClassName("col")[0]
+		var div_element = document.createElement('div');
+		element_resultsByThesisTable_col_row = element_resultsByThesisTable_col.appendChild(div_element)
+		element_resultsByThesisTable_col_row.className = "row"
+
+		// 2a COL left		
+		var div_element = document.createElement('div');
+		element_resultsByThesisTable_col_row_col_left = element_resultsByThesisTable_col_row.appendChild(div_element)
+		element_resultsByThesisTable_col_row_col_left.className = "col"
+		element_resultsByThesisTable_col_row_col_left.innerHTML = buttonContent_Minus
+
+		// 2b COL right
+		var div_element = document.createElement('div');
+		element_resultsByThesisTable_col_row_col_right = element_resultsByThesisTable_col_row.appendChild(div_element)
+		element_resultsByThesisTable_col_row_col_right.className = "col text-center"				
+		element_resultsByThesisTable_col_row_col_right.innerHTML = buttonContent_Plus
+
+		// C. rechte Tabelle / right list - resultsByParty
+		// 1. ROW
+		var element_resultsByPartyTable_col = document.getElementById("resultsByPartyTable").getElementsByClassName("col")[0]
+		var div_element = document.createElement('div');
+		element_resultsByPartyTable_col_row = element_resultsByPartyTable_col.appendChild(div_element)
+		element_resultsByPartyTable_col_row.className = "row"
+
+		// 2a COL left
+		var div_element = document.createElement('div');
+		element_resultsByPartyTable_col_row_col_left = element_resultsByPartyTable_col_row.appendChild(div_element)
+		element_resultsByPartyTable_col_row_col_left.className = "col"
+		element_resultsByPartyTable_col_row_col_left.innerHTML = buttonContent_Minus
+
+		// 2b COL right
+		var div_element = document.createElement('div');
+		element_resultsByPartyTable_col_row_col_right = element_resultsByPartyTable_col_row.appendChild(div_element)
+		element_resultsByPartyTable_col_row_col_right.className = "col text-center"				
+		element_resultsByPartyTable_col_row_col_right.innerHTML = buttonContent_Plus
+
+
+		// setze Werte auf Buttons / set values for buttons 
+		fnCalculate_Buttons(0, intPartiesShowAtEnd)
+
+		// Zeige / verstecke die Zeilen
+		// Show / hide lines 
+		fnShowOnlyIntPartiesAtEnd(0, intPartiesShowAtEnd)
 
 	} // end: else
 
 }
 
 
-// Aufruf bei Klick auf den Button und am Anfang "mow_addon_limit_results_create_buttons()"
-function fnShowOnlyIntPartiesAtEnd_Plus(rowStart, rowEnd) {
+/*
+	Berechne die neuen Werte für die PLUS + MINUS-Buttons 
+	Calculate new values for PLUS + MINUS-buttons 
+
+	Das Skript berechnet die Werte anhand des vorherigen Wertes
+	z.B. 12 Ergebnisse, Start: 5 + 5 = 10 + 5 = 12 (max.) 
+	12 (max.) - 5 = 7 - 5 = 02 - 5 = 01 (min.) 
+	01 (min.) + 5 = 6 + 5 = 11 + 5 = 12 (max.) 
+*/
+function fnCalculate_Buttons(rowStart, rowEnd) {
 
 		
-		rowStart = 0
-		rowEnd = rowEnd + intPartiesShowAtEnd
+//		rowStartMinus = 0
+//		rowStartPlus  = 0
+		rowEndMinus = rowEnd - intPartiesShowAtEnd
+		rowEndPlus  = rowEnd + intPartiesShowAtEnd
 		
-		// onclick-Funktion auf Button PLUS legen 
-		document.getElementById("Buttons_showPartiesAtEnd_resultsShort_plus").setAttribute("onclick","fnShowOnlyIntPartiesAtEnd_Plus("+rowStart+","+rowEnd+")")
+		// verhindere negative Werte 
+		// prevent negative values
+		if (rowEndMinus <= 0)
+		{ rowEndMinus = 1 }
+		
+		// finde alle (Pseudo)-Klassen für die Buttons um die Buttons später zu verändern
+		// find all (pseudo)-classes for the buttons to change the buttons later
+		var buttons_minus = document.getElementsByClassName("Buttons_showPartiesAtEnd_minus")
+		var buttons_plus  = document.getElementsByClassName("Buttons_showPartiesAtEnd_plus")		
+
+		// Klick-Funktionen mit neuen Werten auf die Buttons legen
+		// change click-event with new values 
+		for (var i = 0; i < buttons_plus.length; i++) {
+		    buttons_plus[i].setAttribute("onclick","fnCalculate_Buttons("+rowStart+","+rowEndPlus+")")
+		}
+		for (var i = 0; i < buttons_minus.length; i++) {
+			buttons_minus[i].setAttribute("onclick","fnCalculate_Buttons("+rowStart+","+rowEndMinus+")")
+		}
+		
+
+		// wenn WENIGER Parteien (Zeilen) angezeigt werden sollten, als eigentlich vorhanden sind ...
+		// if the script wants to show FEWER parties (lines) than exists ...
+		if (rowEnd <= 1) {
+			// ... blende den Button aus / ... hide button
+			for (var i = 0; i < buttons_minus.length; i++) {
+				fnFadeOut(buttons_minus[i], 500, 1)
+			}
+		}
+		else {
+			// ... ansonsten zeige den Button / ... otherwise show the button
+			for (var i = 0; i < buttons_minus.length; i++) {
+				fnFadeIn(buttons_minus[i], 500, 1)
+			}
+		}
+
+
+		// wenn MEHR Parteien (Zeilen) angezeigt werden sollten, als eigentlich vorhanden sind ...
+		// if the script wants to show MORE parties (lines) than exists ...
+		if (rowEnd >= intParties) {
+			// ... blende den Button aus /  ... hide button
+			for (var i = 0; i < buttons_plus.length; i++) {
+				fnFadeOut(buttons_plus[i], 500, 1)
+			}
+		}
+		else {
+			// ... ansonsten zeige den Button / ... otherwise show the button
+			for (var i = 0; i < buttons_plus.length; i++) {
+				fnFadeIn(buttons_plus[i], 500, 1)
+			}
+		}
+
+		// Zeige / verstecke die Zeilen
+		// Show / hide lines 		
+		fnShowOnlyIntPartiesAtEnd(rowStart, rowEnd)
+		
+}
+
+
+// Zeige / verstecke die Zeilen
+// Show / hide lines 
+function fnShowOnlyIntPartiesAtEnd(rowStart, rowEnd) {		
 		
 		var element_resultsShortTable_col = document.getElementById("resultsShortTable").getElementsByClassName("col")[0]
 		var element_resultsByThesisTable_col = document.getElementById("resultsByThesisTable").getElementsByClassName("col")[0]
 		
+		// obere (erste) Tabelle + Tabelle sortiert nach Parteien (rechts)
+		// upper (first) list + list sorted by parties (right)
 		for (i = 0; i <= intParties-1; i++) {
 						
 			if ( (i >= rowStart) &&  (i < rowEnd) ) {
-				// obere Tabelle: resultsShortTable
-				element_resultsShortTable_col.getElementsByClassName("row")[i].style.visibility = ""
-				element_resultsShortTable_col.getElementsByClassName("row")[i].style.display = ""
+				// erste Tabelle: resultsShortTable (oben)
+				fnFadeIn(element_resultsShortTable_col.getElementsByClassName("row")[i], 500, 1)
 								
-				// Tabelle sortiert nach Parteien
-				document.getElementById("resultsByPartyHeading"+i).style.visibility = ""
-				document.getElementById("resultsByPartyHeading"+i).style.display = ""
+				// Tabelle sortiert nach Parteien (rechts)
+				fnFadeIn(document.getElementById("resultsByPartyHeading"+i).getElementsByClassName("row")[0], 500, 1)
+				// fnFadeIn(document.getElementById("resultsByPartyAnswersToQuestion"+i), 500, 1)
 			}
 			else {
-				// obere Tabelle: resultsShortTable
-				element_resultsShortTable_col.getElementsByClassName("row")[i].style.visibility = "hidden"
-				element_resultsShortTable_col.getElementsByClassName("row")[i].style.display = "none"
+				// erste Tabelle: resultsShortTable (oben)
+				fnFadeOut(element_resultsShortTable_col.getElementsByClassName("row")[i], 500, 1)
 				
-				// Tabelle sortiert nach Parteien
-				document.getElementById("resultsByPartyHeading"+i).style.visibility = "hidden"
-				document.getElementById("resultsByPartyHeading"+i).style.display = "none"
+				// Tabelle sortiert nach Parteien (rechts)
+				fnFadeOut(document.getElementById("resultsByPartyHeading"+i).getElementsByClassName("row")[0], 500, 1)
+				// fnFadeOut(document.getElementById("resultsByPartyAnswersToQuestion"+i).getElementsByClassName("row")[0], 500, 0)
 			}
 			 
 		} // end: for-intParties
 
 
-		// Tabelle sortiert nach Fragen
+		// Tabelle sortiert nach Fragen (links) / list sorted by questions (left)
 		for (i = 0; i <= intQuestions-1; i++) {
 
 
 			for (j = 0; j <= intParties-1; j++) {
 
 				if ( (j >= rowStart) &&  (j < rowEnd) ) {
-					document.getElementById("resultsByThesisAnswersToQuestion"+i).getElementsByClassName("col")[0].getElementsByClassName("row")[j].style.visibility = ""
-					document.getElementById("resultsByThesisAnswersToQuestion"+i).getElementsByClassName("col")[0].getElementsByClassName("row")[j].style.display = ""														 
+					fnFadeIn(document.getElementById("resultsByThesisAnswersToQuestion"+i).getElementsByClassName("col")[0].getElementsByClassName("row")[j], 500, 1)
 				}
 				else {
-					document.getElementById("resultsByThesisAnswersToQuestion"+i).getElementsByClassName("col")[0].getElementsByClassName("row")[j].style.visibility = "hidden"
-					document.getElementById("resultsByThesisAnswersToQuestion"+i).getElementsByClassName("col")[0].getElementsByClassName("row")[j].style.display = "none"
+					fnFadeOut(document.getElementById("resultsByThesisAnswersToQuestion"+i).getElementsByClassName("col")[0].getElementsByClassName("row")[j], 500, 1)
 				}
 						
 				} // // end: for-intParties
 
 		} // end: for-intQuestions		
-
-		// wenn mehr Parteien angezeigt werden sollten, als eigentlich vorhanden sind ...
-		if (rowEnd >= intParties) {
-			// ... blende den Button aus
-			document.getElementById("Buttons_showPartiesAtEnd_resultsShort_plus").style.visibility = "hidden"
-		}		
 
 	
 }
@@ -181,9 +310,3 @@ function fnShowOnlyIntPartiesAtEnd_Plus(rowStart, rowEnd) {
 
 // Start
 window.addEventListener("load", mow_addon_limit_results__MutationObserver)
-
-/*
-window.onload = function () {
-	mow_addon_limit_results__MutationObserver() 
-}
-*/

--- a/styles/default.css
+++ b/styles/default.css
@@ -63,6 +63,19 @@ a:hover { color:#FF0000; text-decoration:none; }
 }
 
 .social-mail {
-   background: #c6c6c6;
+	background: #c6c6c6;
 	color: #fff;
+}
+
+
+/*	FadeIn + FadeOut */
+
+@keyframes myFadeIn {
+	from { opacity: 0; }
+	to { opacity: 1; }
+}
+
+@keyframes myFadeOut {
+	from { opacity: 1; }
+	to { opacity: 0; }
 }

--- a/system/changelog.md
+++ b/system/changelog.md
@@ -34,6 +34,19 @@
 ## Versions:
 
 
+### stable-v.6.0-BMBF-PTF-20210727
+
+- **Update** for Show only X parties in the list of results right away. The rest is visible on click.
+  - https://github.com/msteudtn/Mat-O-Wahl/issues/21 - Nur die ersten 20 (?) Parteien in Tabellen anzeigen und darunter ein Button "Weitere anzeigen"
+  - `EXTRAS/ADDON_LIMIT_RESULTS.JS`
+  - new: Option to show less results
+  - new / changed: Buttons are shown directly under the (three) result-lists (tables). Before it was just one button at the end. 
+  
+- Slowly starting to **remove jQuery**
+  - **New:** `@keyframes myFadeIn, @keyframes myFadeOut` in `DEFAULT.CSS` to support fading
+  - **New:** functions `fnFadeIn(), fnFadeOut()` in `GENERAL.JS`
+  - e.g. `fnFadeOut(document.getElementById("myId"), 750, 1)` = fade out `#myId` within 750ms and set `display:none` (1)    
+
 ### stable-v.6.0-BMBF-PTF-20210725
 
 - Question in the beginning to ask for the favorite party

--- a/system/general.js
+++ b/system/general.js
@@ -3,7 +3,7 @@
 // License: GPL 3
 // Mathias Steudtner http://www.medienvilla.com
 
-var version = "stable-v.6.0-BMBF-PTF-20210725"
+var version = "stable-v0.6-BMBF-PTF-20210727"
 
 // Globale Variablen
 var arQuestionsShort = new Array();	// Kurzform der Fragen: Atomkraft, Flughafenausbau, ...
@@ -415,4 +415,43 @@ function fnToggleDouble(i)
 		$("#doubleIcon"+i).attr("title",TEXT_ANSWER_NORMAL);
 	}
 	fnReEvaluate();
+}
+
+
+
+// vanilla JavaScript FadeIn / FadeOut
+// Modus = display: "none / block" ändern (0 = nein, 1 = ja)
+function fnFadeIn(el, time, modus) {
+
+	// Default FadeIn / FadeOut-Time
+	if (!time) {time = 500;}
+
+	// Loading CSS 
+	el.style.animation = "myFadeIn "+time+"ms 1"
+	el.style.opacity = 1;
+
+	if (modus == 1) {
+		el.style.display = ""	
+		el.style.visibility = ""
+	}
+}
+
+// vanilla JavaScript FadeIn / FadeOut
+// Modus = visibility show / hidden ändern (0 = nein, 1 = ja)
+function fnFadeOut(el, time, modus) {
+
+	// Default FadeIn / FadeOut-Time
+	if (!time) {time = 500;}
+
+	// Loading CSS 
+	el.style.animation = "myFadeOut "+time+"ms 1"
+	el.style.opacity = 0;
+
+	// hide element from DOM AFTER opacity is set to 0 (setTimeout)
+	if (modus == 1) {
+		window.setTimeout(function() {
+			el.style.display = "none"	
+			el.style.visibility = "hidden"			
+		}, (time-50));		
+	}
 }


### PR DESCRIPTION
- **Update** for Show only X parties in the list of results right away. The rest is visible on click.
  - https://github.com/msteudtn/Mat-O-Wahl/issues/21 - Nur die ersten 20 (?) Parteien in Tabellen anzeigen und darunter ein Button "Weitere anzeigen"
  - `EXTRAS/ADDON_LIMIT_RESULTS.JS`
  - new: Option to show less results
  - new / changed: Buttons are shown directly under the (three) result-lists (tables). Before it was just one button at the end. 
  
- Slowly starting to **remove jQuery**
  - **New:** `@keyframes myFadeIn, @keyframes myFadeOut` in `DEFAULT.CSS` to support fading
  - **New:** functions `fnFadeIn(), fnFadeOut()` in `GENERAL.JS`
  - e.g. `fnFadeOut(document.getElementById("myId"), 750, 1)` = fade out `#myId` within 750ms and set `display:none` (1)    
