### PR TITLE
Fehler in statistischer Auswertung beheben

### DIFF
--- a/system/general.js
+++ b/system/general.js
@@ -174,9 +174,10 @@ function fnSendResults(arResults, arPersonalPositions)
 {
 	// Korrektur der Parteiposition (-1,0,1) mit den Informationen aus der doppelten Wertung (-2,-1,0,1,2)
 	// Marius Nisslmueller, Bad Honnef, Juni 2020
+	// Bedingung für übersprungene Frage hinzugefügt
 	arPersonalPositionsForStats = arPersonalPositions.slice(); // Damit arPersonalPositions nicht verändert wird
 	for(let i=0; i<arPersonalPositionsForStats.length; i++){
-		if(arVotingDouble[i]){
+		if(arVotingDouble[i] && arPersonalPositionsForStats[i] < 99){
 		    arPersonalPositionsForStats[i] *= 2; 
 		}
 	}

--- a/system/output.js
+++ b/system/output.js
@@ -274,6 +274,12 @@ function fnJumpToQuestionNumber(questionNumber)
 	// alten Inhalt ausblenden und loeschen
 	$("#navigationJumpToQuestion").fadeOut(500).empty().hide();
 
+	// Durchlauf des Arrays bis zur ausgewählten Frage und Setzen der 99, falls NaN
+	for (i =0; i<questionNumber; i++) {
+		if (isNaN(arPersonalPositions[i])) {
+			arPersonalPositions[i] = 99;
+		}
+	}
 
 	var maxQuestionsPerLine = 12;  // z.B. 16
 


### PR DESCRIPTION
output.js fnJumpToQuestionNumber
- Durchlauf des Arrays und Setzen der 99, falls NaN

general.js fnSendResults
- Werte nur mit 2 multiplizieren, wenn nicht 99 (übersprungen)

- Alternativ könnte auch das arPersonalPositions direkt mit 99er-Werten erstellt werden.
- In results.txt konnte ich keine 198 mehr finden.