### PR TITLE
Fix 0.6.0.2

### DIFF
--- a/system/changelog.md
+++ b/system/changelog.md
@@ -21,6 +21,10 @@
 
 ## Versions:
 
+### 0.6.0.2.20211031
+
+- Updated error message(s) in `QUICKTEST.HTML`. Some users started Mat-o-Wahl locally but it didn't point out, that the **browsers block reading local files**. Also, added a link to the online-help. 
+
 ### 0.6.0.1.20211009
 
 - Update (Clarification) in the privacy statement. The user didn't really know, who he/she was helping to improve the application. Me or the people running the current Mat-o-Wahl?

--- a/system/general.js
+++ b/system/general.js
@@ -3,7 +3,7 @@
 // License: GPL 3
 // Mathias Steudtner http://www.medienvilla.com
 
-var version = "0.6.0.1.20211009"
+var version = "0.6.0.2.20211031"
 
 // Globale Variablen
 var arQuestionsShort = new Array();	// Kurzform der Fragen: Atomkraft, Flughafenausbau, ...
@@ -39,8 +39,8 @@ function fnReadCsv(csvFile,fnCallback)
 		console.log("Mat-O-Wahl ERROR - Reading CSV-file \n Code - objXML-Status: "+objXML.status+" \n Code - textStatus: "+textStatus+" \n Code - errorThrown: "+errorThrown+" \n Name and folder of CSV-file should be: "+csvFile+" \n\nPossible solutions: Check for capital letters? OR check the extension of the file (csv / xls / xlsx)? OR is the file in the wrong folder? OR are you working on a local machine :( instead of a server? See documentation on www.mat-o-wahl.de"); 
 		// document.getElementById("descriptionAddonTop").innerHTML("nanu. Da ist etwas schief gegangen.")
 			$("#descriptionExplanation").css("color","red").css("font-size", "150%")
-			text = "<p>Nanu? Da ist etwas schief gegangen. Einige Dateien konnten nicht geladen werden. <br /> Sind Sie ein Besucher der Seite? Dann geben Sie bitte dem Administrator der Webseite Bescheid. <br /> Sind Sie der Administrator? Dann schauen Sie bitte in die Browser-Konsole.</p>"
-			text += "<p>Oh? Something went wrong. Some files couldn't be loaded. <br /> Are you a visitor of this site? Please inform the admin of the site. <br /> Are you the admin? Please check the browser-console.</p>"
+			text = "<p>Nanu? Da ist etwas schief gegangen. Einige Dateien konnten nicht geladen werden. <br /> Sind Sie ein Besucher der Seite? Dann geben Sie bitte dem Administrator der Webseite Bescheid. <br /> Sind Sie der Administrator? Dann schauen Sie bitte in die Browser-Konsole (Strg+Umschalt+i) und/oder öffnen Sie die <q>quicktest.html</q>.</p>"
+			text += "<p>Oh? Something went wrong. Some files couldn't be loaded. <br /> Are you a visitor of this site? Please inform the admin of the site. <br /> Are you the admin? Please check the browser-console (Ctrl+Shift+i) and/or open <q>quicktest.html</q>.</p>"
 			$("#descriptionExplanation").html(text)
 		}
 		})

--- a/system/quicktest.js
+++ b/system/quicktest.js
@@ -383,6 +383,21 @@ function fnTestShowAll()
 
 */
 
+
+	// Protokoll prüfen - file:// oder http(s)://
+	var currentProtocol = window.location.protocol;
+	currentProtocol = currentProtocol.substr(0,4)
+	if (currentProtocol != "http") {
+		counterError++
+			$("#testOtherDe").append("<b>("+counterError+").</b>")
+				.append(" Der Browser verhindert, dass Dateien von der lokalen Festplatte gelesen werden. Lösungsvorschläge finden Sie in der Online-Dokumentation unter <a href='https://www.mat-o-wahl.de/dokumentation.html#technikHttp' target='_blank'>Testen der Einstellungen</a>. ")
+				.append("<br />");
+			$("#testOtherEn").append("<b>("+counterError+").</b>")
+				.append(" The browser blocks loading local files. You can find possible solutions in the online-help at <a href='https://www.mat-o-wahl.de/dokumentation.html#technikHttp' target='_blank'>Testen der Einstellungen</a> (German). ")
+				.append("<br />");		
+		}
+
+
 	// Abschlussevaluation - Last check
 	if (counterError > 0)
 	{


### PR DESCRIPTION
Updated error message(s) in `QUICKTEST.HTML`. 
- Some users started Mat-o-Wahl locally but it didn't point out, that the **browsers block reading local files**. 
- Also, added a link to the online-help.