### PR TITLE
Issue 70 no details with textfilter

### DIFF
--- a/extras/addon_contacts_in_results.js
+++ b/extras/addon_contacts_in_results.js
@@ -1,0 +1,184 @@
+///////////////////////////////////////////////////////////////////////
+// DEFINITIONEN *** DEFINITIONS
+// http://www.mat-o-wahl.de
+
+// FUNKTION / FUNCTION
+// * Erstellt 1-x Buttons für die Kontaktaufnahme per E-Mail oder Telefon
+// * Creates 1-x buttons for contact via mail or telephone  
+
+
+// 1.) Allgemeine Angaben
+// General Settings
+var CONTACT_ACTIVE_EMAIL = 1
+var CONTACT_ACTIVE_TEL = 1
+
+var CONTACT_BUTTON_EMAIL = "Kontakt per E-Mail"
+var CONTACT_BUTTON_TEL = "Kontakt per Telefon"
+
+var CONTACT_ADDRESS_EMAIL = "info@meine-freiwilligenagentur.de"
+var CONTACT_ADDRESS_TEL = "+49123456789"
+
+var CONTACT_SUBJECT_EMAIL = "Mitwirk-o-Mat - Anfrage zu Vereinen für Kennenlerngespräch"
+
+var CONTACT_TEXT_EMAIL = "Hallo, \n\n\nich habe gerade den Mitwirk-o-Mat ausgeführt und interessiere mich für einen bestimmten Verein. \n\nBitte ruft mich doch mal an oder schreibt mir, so dass ich den Verein besser kennen lernen kann."
+var CONTACT_TEXT_TEL = ""
+
+
+
+
+// 2.) In der DEFINITION.JS in den Erweiterten Einstellungen das Add-On eintragen.
+// Add the add-on to the advanced settings in DEFINITION.JS
+// var addons = ["extras/addon_contacts_in_results.js"]
+
+// 3.) Fertig. 
+// That's it.
+
+
+///////////////////////////////////////////////////////////////////////  
+
+
+// Hier kommt nur noch Quellcode. Bitte gehen Sie weiter. Hier gibt es nichts zu sehen.
+// That's just source code. Please move on. Nothing to see here.
+
+
+///////////////////////////////////////////////////////////////////////
+
+
+// MutationObserver starten - prüft Änderungen im DOM
+// https://medium.com/better-programming/js-mutationobserver-1d7aed479da2
+// https://developer.mozilla.org/de/docs/Web/API/MutationObserver
+function mow_addon_textfilter_MutationObserver() {
+
+	// zu überwachende Zielnode (target) auswählen
+	var target = document.querySelector('#resultsHeading');
+	 
+	// eine Instanz des Observers erzeugen und Callback-Funktion aufrufen
+	var observer = new MutationObserver(mow_addon_contacts_create_content)
+	 
+	// Konfiguration des Observers: alles melden - Änderungen an Daten, Kindelementen und Attributen
+	var config = { 
+		attributes: true, 
+		childList: true, 
+		subtree: true };
+	 
+	// eigentliche Observierung starten und Zielnode und Konfiguration übergeben
+	observer.observe(target, config);
+	 
+	// später: Observation wieder einstellen
+	// observer.disconnect();
+}
+
+
+// Buttons in Addon-DIV in INDEX.HTML schreiben
+function mow_addon_contacts_create_content() {
+
+	// id "#resultsHeading" wird in fnStart() am Anfang geleert (empty()).
+	// -> mutationObserver erkennt Änderung und aktiviert diese Funktion :(
+	// -> prüfen, ob Inhalt in DIV existiert 
+	resultsHeadingContent = $("#resultsHeading").text()
+
+	if (!resultsHeadingContent) {
+		// nix. Noch keine Ergebnisse im DIV
+	}
+	// schreibe Kontakt-Buttons
+	else {
+
+		// gehe durch Array und schreibe Inhalt
+		for (j = 0; j <= (intParties-1); j++)
+		{
+			var partyNum=arSortParties[j];	// aus "output.js" kopiert. :)
+			
+			var divContent = "";
+	
+			// neue Bootstrap-ROW-Zeile		
+			divContent += '<div class="row border rounded mow-row-striped " id="resultsShortPartyAddonContactsInResults'+partyNum+'">'
+
+			// wenn die Variable auf 1 / aktiv gesetzt ist, schreibe Button
+			if (CONTACT_ACTIVE_EMAIL > 0 ) {	
+				
+				divContent += ' <div class="col">'
+				divContent += '  <a href="mailto:'+CONTACT_ADDRESS_EMAIL+'?subject='+encodeURI(CONTACT_SUBJECT_EMAIL)+'&body='+encodeURI(CONTACT_TEXT_EMAIL)+'_'+mow_addon_contacts_add_results_to_text()+'" role="button" class="btn btn-sm btn-success">'+CONTACT_BUTTON_EMAIL+'</a>'
+				divContent += ' </div>'
+			}
+
+			// wenn die Variable auf 1 / aktiv gesetzt ist, schreibe Button
+			if (CONTACT_ACTIVE_TEL > 0 ) {
+				divContent += ' <div class="col">'
+				divContent += '  <a href="tel:'+CONTACT_ADDRESS_TEL+'" role="button" class="btn btn-sm btn-success" aria-pressed="true">'+CONTACT_BUTTON_TEL+'</a>'
+				divContent += ' </div>'
+			}
+
+			divContent += '</div>'
+			
+			// TEST TEST TEST
+			divContent += '<div class="row border rounded mow-row-striped" id="nixTest'+partyNum+'">'
+				divContent += ' <div class="col"> Testzeile ohne Funktion j: '+j+' </div>'
+			divContent += '</div>'
+
+			// richtige Nummer der Partei finden und die neue ROW-Zeile dahinter einfügen    	
+			var element_resultsShortParty = document.getElementById("resultsShortParty"+partyNum)		
+			element_resultsShortParty.insertAdjacentHTML('afterend', divContent)
+						
+		} // end: for intParties
+
+		// Klick-Funktion auf die gesamte Ergebnis-Zeile legen und am Anfang ausblenden
+		mow_addon_contacts_add_click_on_row()
+		
+
+	} // end: else
+
+}
+
+
+// Klick-Funktion auf die gesamte Ergebnis-Zeile legen und am Anfang ausblenden
+function mow_addon_contacts_add_click_on_row() {
+	// Click-Funktion auf PARTEINAME-Zeile legen zum Anzeigen der BUTTONS 
+	// kopiert / angepasst aus "output.js" - ca. Zeile 450
+	
+	for (let i = 0; i <= (intParties-1); i++)
+	{
+		// Klickfunktion - bei Überschrift
+		$("#resultsShortParty"+i).click(function () { 
+				$("#resultsShortPartyAddonContactsInResults"+i).toggle(500);
+
+				$("#nixTest"+i).toggle(500);				
+			});	
+
+		// am Anfang ausblenden
+		$("#resultsShortPartyAddonContactsInResults"+i).hide(500);
+		
+		$("#nixTest"+i).hide(500);
+	}
+	
+}
+
+function mow_addon_contacts_add_results_to_text() {
+
+		var statistics_text = "\n\n Meine Ergebnisse lauteten wie folgt: \n\n"
+
+		for (i = 0; i <= (intParties-1); i++)
+		{
+			var partyNum=arSortParties[i];	// aus "output.js" kopiert. :)
+
+			var partyNameLong = arPartyNamesLong[partyNum];
+			var partyPoints = arResults[partyNum];
+			
+			statistics_text += "\n"+partyNameLong+": "+partyPoints+" Punkte";
+			
+		}
+		statistics_text = encodeURI(statistics_text);
+		return statistics_text;
+
+}
+
+
+
+
+// Start
+window.addEventListener("load", mow_addon_textfilter_MutationObserver)
+
+/*
+window.onload = function () {
+	mow_addon_textfilter_MutationObserver() 
+}
+*/

--- a/extras/addon_contacts_in_results.js
+++ b/extras/addon_contacts_in_results.js
@@ -18,7 +18,7 @@ var CONTACT_BUTTON_TEL = "Kontakt per Telefon"
 var CONTACT_ADDRESS_EMAIL = "info@meine-freiwilligenagentur.de"
 var CONTACT_ADDRESS_TEL = "+49123456789"
 
-var CONTACT_SUBJECT_EMAIL = "Mitwirk-o-Mat - Anfrage zu Vereinen für Kennenlerngespräch"
+var CONTACT_SUBJECT_EMAIL = "Mitwirk-o-Mat - Ich habe Interesse an folgendem Verein: "
 
 var CONTACT_TEXT_EMAIL = "Hallo, \n\n\nich habe gerade den Mitwirk-o-Mat ausgeführt und interessiere mich für einen bestimmten Verein. \n\nBitte ruft mich doch mal an oder schreibt mir, so dass ich den Verein besser kennen lernen kann."
 var CONTACT_TEXT_TEL = ""
@@ -91,13 +91,13 @@ function mow_addon_contacts_create_content() {
 			var divContent = "";
 	
 			// neue Bootstrap-ROW-Zeile		
-			divContent += '<div class="row border rounded mow-row-striped " id="resultsShortPartyAddonContactsInResults'+partyNum+'">'
+			divContent += '<div class="row" id="resultsShortPartyAddonContactsInResults'+partyNum+'">'
 
 			// wenn die Variable auf 1 / aktiv gesetzt ist, schreibe Button
 			if (CONTACT_ACTIVE_EMAIL > 0 ) {	
 				
 				divContent += ' <div class="col">'
-				divContent += '  <a href="mailto:'+CONTACT_ADDRESS_EMAIL+'?subject='+encodeURI(CONTACT_SUBJECT_EMAIL)+'&body='+encodeURI(CONTACT_TEXT_EMAIL)+'_'+mow_addon_contacts_add_results_to_text()+'" role="button" class="btn btn-sm btn-success">'+CONTACT_BUTTON_EMAIL+'</a>'
+				divContent += '  <a href="mailto:'+CONTACT_ADDRESS_EMAIL+'?subject='+encodeURI(CONTACT_SUBJECT_EMAIL)+''+arPartyNamesLong[partyNum]+'&body='+encodeURI(CONTACT_TEXT_EMAIL)+'_'+mow_addon_contacts_add_results_to_text()+'" role="button" class="btn btn-sm btn-success">'+CONTACT_BUTTON_EMAIL+'</a>'
 				divContent += ' </div>'
 			}
 
@@ -111,7 +111,7 @@ function mow_addon_contacts_create_content() {
 			divContent += '</div>'
 			
 			// TEST TEST TEST
-			divContent += '<div class="row border rounded mow-row-striped" id="nixTest'+partyNum+'">'
+			divContent += '<div class="row" id="nixTest'+partyNum+'">'
 				divContent += ' <div class="col"> Testzeile ohne Funktion j: '+j+' </div>'
 			divContent += '</div>'
 

--- a/extras/addon_limit_results.js
+++ b/extras/addon_limit_results.js
@@ -23,7 +23,7 @@
 	
 */
 
-var intPartiesShowAtEnd = 3;
+var intPartiesShowAtEnd = 4;
 
 
 // 2.) Text für Buttons
@@ -76,8 +76,8 @@ function mow_addon_limit_results__MutationObserver() {
 
 
 
-// Buttons in INDEX.HTML schreiben
-// Write buttons into INDEX.HTML
+// Buttons in INDEX.HTML schreiben (nur 1x am Anfang)
+// Write buttons into INDEX.HTML (only once in the beginning)
 function mow_addon_limit_results_create_buttons() {
 
 	/* id "#resultsHeading" wird in fnStart() am Anfang geleert (empty()).
@@ -180,6 +180,7 @@ function mow_addon_limit_results_create_buttons() {
 
 		// Zeige / verstecke die Zeilen
 		// Show / hide lines 
+		
 		fnShowOnlyIntPartiesAtEnd(0, intPartiesShowAtEnd)
 
 	} // end: else
@@ -197,7 +198,6 @@ function mow_addon_limit_results_create_buttons() {
 	01 (min.) + 5 = 6 + 5 = 11 + 5 = 12 (max.) 
 */
 function fnCalculate_Buttons(rowStart, rowEnd) {
-
 		
 //		rowStartMinus = 0
 //		rowStartPlus  = 0
@@ -209,6 +209,10 @@ function fnCalculate_Buttons(rowStart, rowEnd) {
 		if (rowEndMinus <= 0)
 		{ rowEndMinus = 1 }
 		
+		// Normalerweise würde man einfach nur Anfang und Ende an die Funktion "fnCalculate_Buttons(start,end)" übergeben. 
+		// Aber das Addon "addon_results_textfilter_by_button.js" setzt alle Filter zurück. 
+		// Deshalb übergebe ich stattdessen ein Array der zu filternden Zeilen. fnCalculate_Buttons("[0,1,2,3,4,5,6]")
+		
 		// finde alle (Pseudo)-Klassen für die Buttons um die Buttons später zu verändern
 		// find all (pseudo)-classes for the buttons to change the buttons later
 		var buttons_minus = document.getElementsByClassName("Buttons_showPartiesAtEnd_minus")
@@ -218,9 +222,11 @@ function fnCalculate_Buttons(rowStart, rowEnd) {
 		// change click-event with new values 
 		for (var i = 0; i < buttons_plus.length; i++) {
 		    buttons_plus[i].setAttribute("onclick","fnCalculate_Buttons("+rowStart+","+rowEndPlus+")")
+		    // console.log("BTN+ "+i+" Start: "+rowStart+" Ende: "+rowEndPlus)
 		}
 		for (var i = 0; i < buttons_minus.length; i++) {
 			buttons_minus[i].setAttribute("onclick","fnCalculate_Buttons("+rowStart+","+rowEndMinus+")")
+			// console.log("BTN- "+i+" Start: "+rowStart+" Ende: "+rowEndMinus)
 		}
 		
 
@@ -265,7 +271,7 @@ function fnCalculate_Buttons(rowStart, rowEnd) {
 // Zeige / verstecke die Zeilen
 // Show / hide lines 
 function fnShowOnlyIntPartiesAtEnd(rowStart, rowEnd) {		
-		
+				
 		// Anzahl der Zeilen (mit Bootstrap-Klasse "row") finden für FOR-Schleife  später
 		// Nur relevant in der #resultsShortTable (oben) falls es noch extra Zeilen aus anderen Addons gibt.
 		var resultsShortTable_rows = document.getElementById("resultsShortTable").getElementsByClassName("row")
@@ -278,7 +284,7 @@ function fnShowOnlyIntPartiesAtEnd(rowStart, rowEnd) {
 		// 1. obere (erste) Tabelle #resultsShort + 2. Tabelle sortiert nach Parteien (rechts) #resultsByParty
 		// 1. upper (first) list #resultsShort + 2. list sorted by parties (right) #resultsByParty
 		for (i = 0; i <= intParties-1; i++) {
-						
+
 			if ( (i >= rowStart) &&  (i < rowEnd) ) {
 				
 				// erste Tabelle: resultsShortTable (oben)
@@ -293,7 +299,9 @@ function fnShowOnlyIntPartiesAtEnd(rowStart, rowEnd) {
 						// Standardzeile (Parteiname, Bild, Prozent, Beschreibung) -> anzeigen
 						// fnFadeIn(element_resultsShortTable_col.getElementsByClassName("row")[j], 500, 1)
 						element_resultsShortTable_col.getElementsByClassName("row")[j].style.display = ""
+						element_resultsShortTable_col.getElementsByClassName("row")[j].parentElement.style.display = ""  // #resultsShortPartyClampX - wird mehrfach ausgeführt :(
 						element_resultsShortTable_col.getElementsByClassName("row")[j].style.visibility = ""
+						element_resultsShortTable_col.getElementsByClassName("row")[j].parentElement.style.visibility = ""  // #resultsShortPartyClampX - wird mehrfach ausgeführt :(
 						// console.log("IF-IN  i: "+i+" j: "+j+" multiplikator: "+multiplikator)	
 					}
 					// i: - 0 0 - 1 1 - 2 2 
@@ -311,7 +319,7 @@ function fnShowOnlyIntPartiesAtEnd(rowStart, rowEnd) {
 				// fnFadeIn(document.getElementById("resultsByPartyAnswersToQuestion"+i).getElementsByClassName("row")[0], 500, 1)
 				
 				document.getElementById("resultsByPartyHeading"+i).getElementsByClassName("row")[0].style.display = ""
-				document.getElementById("resultsByPartyAnswersToQuestion"+i).getElementsByClassName("row")[0].style.display = ""
+				document.getElementById("resultsByPartyAnswersToQuestion"+i).getElementsByClassName("row")[0].style.display = ""  // #resultsShortPartyClampX - wird mehrfach ausgeführt :(
 			}
 			
 			// Alle Zeilen, die außerhalb des Limits liegen -> ausblenden!
@@ -325,6 +333,7 @@ function fnShowOnlyIntPartiesAtEnd(rowStart, rowEnd) {
 						// Standardzeile (Parteiname, Bild, Prozent, Beschreibung) -> ausblenden
 						// fnFadeOut(element_resultsShortTable_col.getElementsByClassName("row")[j], 500, 1)
 						element_resultsShortTable_col.getElementsByClassName("row")[j].style.display = "none"
+						element_resultsShortTable_col.getElementsByClassName("row")[j].parentElement.style.display = "none" // #resultsShortPartyClampX - wird mehrfach ausgeführt :(
 						// element_resultsShortTable_col.getElementsByClassName("row")[j].style.visibility = "hidden"
 						// console.log("ELSE-if  i: "+i+" j: "+j+" multiplikator: "+multiplikator)	
 					}
@@ -334,6 +343,7 @@ function fnShowOnlyIntPartiesAtEnd(rowStart, rowEnd) {
 						// Standardzeile (Parteiname, Bild, Prozent, Beschreibung) -> verstecken 
 						// fnFadeOut() nutzt CSS:visibility und CSS:display -> Anzeigeprobleme! :(
 						element_resultsShortTable_col.getElementsByClassName("row")[j].style.display = "none"
+						element_resultsShortTable_col.getElementsByClassName("row")[j].parentElement.style.display = "none"  // #resultsShortPartyClampX - wird mehrfach ausgeführt :(
 						// console.log("ELSE-else i: "+i+" j: "+j+" multiplikator: "+multiplikator)
 						}
 
@@ -373,6 +383,12 @@ function fnShowOnlyIntPartiesAtEnd(rowStart, rowEnd) {
 	
 }
 
+
+function fnTestVonTextfilter() {
+	
+	// console.log("Aufruf in Limit-Results aus Textfilter - "+arrayRowNumbersTextfilter)
+	stringRowNumbersTextfilter = "";
+	}
 
 // Start
 window.addEventListener("load", mow_addon_limit_results__MutationObserver)

--- a/extras/addon_limit_results.js
+++ b/extras/addon_limit_results.js
@@ -115,7 +115,7 @@ function mow_addon_limit_results_create_buttons() {
 		var element_resultsShortTable_col = document.getElementById("resultsShortTable").getElementsByClassName("col")[0]
 		var div_element = document.createElement('div');
 		resultsShortTable_col_row = element_resultsShortTable_col.appendChild(div_element)
-		resultsShortTable_col_row.className = "row"
+		resultsShortTable_col_row.className = "row showAlwaysIsTrue" // "showAlwaysIsTrue" ist eine Pseudo-CSS-Klasse. -> nur für andere Addons als Warnung, z.B. "addon_results_textfilter_by_button.js"
 		
 		// 2a COL left
 		var div_element = document.createElement('div');
@@ -140,7 +140,7 @@ function mow_addon_limit_results_create_buttons() {
 			var element_resultsByThesisTable_col = document.getElementById("resultsByThesisAnswersToQuestion"+i).getElementsByClassName("col")[0]
 			var div_element = document.createElement('div');
 			element_resultsByThesisTable_col_row = element_resultsByThesisTable_col.appendChild(div_element)
-			element_resultsByThesisTable_col_row.className = "row"
+			element_resultsByThesisTable_col_row.className = "row showAlwaysIsTrue" // "showAlwaysIsTrue" ist eine Pseudo-CSS-Klasse. -> nur für andere Addons als Warnung, z.B. "addon_results_textfilter_by_button.js"
 
 			// 2a COL left		
 			var div_element = document.createElement('div');
@@ -160,7 +160,7 @@ function mow_addon_limit_results_create_buttons() {
 		var element_resultsByPartyTable_col = document.getElementById("resultsByPartyTable").getElementsByClassName("col")[0]
 		var div_element = document.createElement('div');
 		element_resultsByPartyTable_col_row = element_resultsByPartyTable_col.appendChild(div_element)
-		element_resultsByPartyTable_col_row.className = "row"
+		element_resultsByPartyTable_col_row.className = "row showAlwaysIsTrue" // "showAlwaysIsTrue" ist eine Pseudo-CSS-Klasse. -> nur für andere Addons als Warnung, z.B. "addon_results_textfilter_by_button.js"
 
 		// 2a COL left
 		var div_element = document.createElement('div');
@@ -266,44 +266,104 @@ function fnCalculate_Buttons(rowStart, rowEnd) {
 // Show / hide lines 
 function fnShowOnlyIntPartiesAtEnd(rowStart, rowEnd) {		
 		
+		// Anzahl der Zeilen (mit Bootstrap-Klasse "row") finden für FOR-Schleife  später
+		// Nur relevant in der #resultsShortTable (oben) falls es noch extra Zeilen aus anderen Addons gibt.
+		var resultsShortTable_rows = document.getElementById("resultsShortTable").getElementsByClassName("row")
+		var resultsShortTable_rows_length = resultsShortTable_rows.length - 1;
+		var multiplikator = resultsShortTable_rows_length / intParties // z.B. 8 Zeilen / 4 Parteien = 2
+				
 		var element_resultsShortTable_col = document.getElementById("resultsShortTable").getElementsByClassName("col")[0]
 		var element_resultsByThesisTable_col = document.getElementById("resultsByThesisTable").getElementsByClassName("col")[0]
 		
-		// obere (erste) Tabelle + Tabelle sortiert nach Parteien (rechts)
-		// upper (first) list + list sorted by parties (right)
+		// 1. obere (erste) Tabelle #resultsShort + 2. Tabelle sortiert nach Parteien (rechts) #resultsByParty
+		// 1. upper (first) list #resultsShort + 2. list sorted by parties (right) #resultsByParty
 		for (i = 0; i <= intParties-1; i++) {
 						
 			if ( (i >= rowStart) &&  (i < rowEnd) ) {
+				
 				// erste Tabelle: resultsShortTable (oben)
-				fnFadeIn(element_resultsShortTable_col.getElementsByClassName("row")[i], 500, 1)
-								
+				// Es kann sein, dass andere Addons zusätzliche Zeilen (rows) eingefügt haben. (z.B. addon_contacts_in_results.js) 
+				// Nun wird geprüft, ob es eine normale Zeile ist oder eine eingefügte Zeile.
+				
+				// Bsp.: 5 Parteien x (1 Standardzeile + 2 extra Zeilen) = Multiplikator von 3 
+				for (j = (i*multiplikator); j <= ( (i+1) * multiplikator-1); j++) {
+					// i: 0 - - 1 - - 2 - -
+					// j: 0 - - 3 - - 6 - - 
+					if (j == (i*multiplikator)) {
+						// Standardzeile (Parteiname, Bild, Prozent, Beschreibung) -> anzeigen
+						// fnFadeIn(element_resultsShortTable_col.getElementsByClassName("row")[j], 500, 1)
+						element_resultsShortTable_col.getElementsByClassName("row")[j].style.display = ""
+						element_resultsShortTable_col.getElementsByClassName("row")[j].style.visibility = ""
+						// console.log("IF-IN  i: "+i+" j: "+j+" multiplikator: "+multiplikator)	
+					}
+					// i: - 0 0 - 1 1 - 2 2 
+					// j: - 1 2 - 4 5 - 7 8 
+					else {
+						// nix - Zeile sollte durch das Addon bereits ausgeblendet sein
+						// console.log("IF-out i: "+i+" j: "+j+" multiplikator: "+multiplikator)
+					}
+					
+				}
+
+
 				// Tabelle sortiert nach Parteien (rechts)
-				fnFadeIn(document.getElementById("resultsByPartyHeading"+i).getElementsByClassName("row")[0], 500, 1)
-				// fnFadeIn(document.getElementById("resultsByPartyAnswersToQuestion"+i), 500, 1)
+				// fnFadeIn(document.getElementById("resultsByPartyHeading"+i).getElementsByClassName("row")[0], 500, 1)
+				// fnFadeIn(document.getElementById("resultsByPartyAnswersToQuestion"+i).getElementsByClassName("row")[0], 500, 1)
+				
+				document.getElementById("resultsByPartyHeading"+i).getElementsByClassName("row")[0].style.display = ""
+				document.getElementById("resultsByPartyAnswersToQuestion"+i).getElementsByClassName("row")[0].style.display = ""
 			}
+			
+			// Alle Zeilen, die außerhalb des Limits liegen -> ausblenden!
 			else {
+				
 				// erste Tabelle: resultsShortTable (oben)
-				fnFadeOut(element_resultsShortTable_col.getElementsByClassName("row")[i], 500, 1)
+				// i: 3 - - -4 - - -5 - - 
+				// j: 9 - - 12 - - 15 - - 
+				for (j = (i*multiplikator); j <= ( (i+1) * multiplikator-1); j++) {
+					if (j == (i*multiplikator)) {
+						// Standardzeile (Parteiname, Bild, Prozent, Beschreibung) -> ausblenden
+						// fnFadeOut(element_resultsShortTable_col.getElementsByClassName("row")[j], 500, 1)
+						element_resultsShortTable_col.getElementsByClassName("row")[j].style.display = "none"
+						// element_resultsShortTable_col.getElementsByClassName("row")[j].style.visibility = "hidden"
+						// console.log("ELSE-if  i: "+i+" j: "+j+" multiplikator: "+multiplikator)	
+					}
+					// i: -- -3 -3 -- -4 -4 -- -5 -5 
+					// j: -- 10 11 -- 13 14 -- 16 17 
+					else {
+						// Standardzeile (Parteiname, Bild, Prozent, Beschreibung) -> verstecken 
+						// fnFadeOut() nutzt CSS:visibility und CSS:display -> Anzeigeprobleme! :(
+						element_resultsShortTable_col.getElementsByClassName("row")[j].style.display = "none"
+						// console.log("ELSE-else i: "+i+" j: "+j+" multiplikator: "+multiplikator)
+						}
+
+				}			
 				
 				// Tabelle sortiert nach Parteien (rechts)
-				fnFadeOut(document.getElementById("resultsByPartyHeading"+i).getElementsByClassName("row")[0], 500, 1)
-				// fnFadeOut(document.getElementById("resultsByPartyAnswersToQuestion"+i).getElementsByClassName("row")[0], 500, 0)
+				// fnFadeOut(document.getElementById("resultsByPartyHeading"+i).getElementsByClassName("row")[0], 500, 1)
+				// fnFadeOut(document.getElementById("resultsByPartyAnswersToQuestion"+i).getElementsByClassName("row")[0], 500, 1)
+				
+				document.getElementById("resultsByPartyHeading"+i).getElementsByClassName("row")[0].style.display = "none"
+				document.getElementById("resultsByPartyAnswersToQuestion"+i).getElementsByClassName("row")[0].style.display = "none"
+				
 			}
 			 
 		} // end: for-intParties
 
 
-		// Tabelle sortiert nach Fragen (links) / list sorted by questions (left)
+		// 3. Tabelle sortiert nach Fragen (links) / 3. list sorted by questions (left) #resultsByThesis
 		for (i = 0; i <= intQuestions-1; i++) {
 
 
 			for (j = 0; j <= intParties-1; j++) {
 
 				if ( (j >= rowStart) &&  (j < rowEnd) ) {
-					fnFadeIn(document.getElementById("resultsByThesisAnswersToQuestion"+i).getElementsByClassName("col")[0].getElementsByClassName("row")[j], 500, 1)
+					// fnFadeIn(document.getElementById("resultsByThesisAnswersToQuestion"+i).getElementsByClassName("col")[0].getElementsByClassName("row")[j], 500, 1)
+					document.getElementById("resultsByThesisAnswersToQuestion"+i).getElementsByClassName("col")[0].getElementsByClassName("row")[j].style.display = ""
 				}
 				else {
-					fnFadeOut(document.getElementById("resultsByThesisAnswersToQuestion"+i).getElementsByClassName("col")[0].getElementsByClassName("row")[j], 500, 1)
+					// fnFadeOut(document.getElementById("resultsByThesisAnswersToQuestion"+i).getElementsByClassName("col")[0].getElementsByClassName("row")[j], 500, 1)
+					document.getElementById("resultsByThesisAnswersToQuestion"+i).getElementsByClassName("col")[0].getElementsByClassName("row")[j].style.display = "none"
 				}
 						
 				} // // end: for-intParties

--- a/extras/addon_results_textfilter_by_button.js
+++ b/extras/addon_results_textfilter_by_button.js
@@ -159,24 +159,32 @@ function mow_addon_textfilter_filter_tables(search_keyword, idNumber) {
 function mow_addon_textfilter_hide_show_row(search_keyword, tableID) {
 	
    table = document.getElementById(tableID);
-	// zeile = table.getElementsByTagName("tr")
+
+
 	zeile = table.getElementsByClassName("row")
-//	console.log("Anzahl:" +zeile.length+" ID: "+tableID)
+
+
 
 	// Durch alle Zeilen gehen und diejenigen verstecken, ohne Suchbegriff.
 	for (i = 0; i < zeile.length; i++) {
-		{
+		{	
+
 			// console.log(i+" "+zeile[i].textContent)
 			txtValue = zeile[i].textContent || zeile[i].innerText;
-//			console.log(i+" "+txtValue)
 
-			// wenn Suchbegriff nicht gefunden, dann CSS-display-Eigenschaft zurücksetzen.
-			if (txtValue.toUpperCase().indexOf(search_keyword) > -1) {
-				zeile[i].style.display = "" 
+	
+			// Wenn Suchbegriff gefunden, dann CSS-display-Eigenschaft zurücksetzen. = anzeigen
+			// ... oder wenn CSS-(Pseudo)-Klasse "showAlwaysIsTrue" vorhanden ist = anzeigen (Buttons von addon_limit_results.js)
+			if ( (txtValue.toUpperCase().indexOf(search_keyword) > -1) || ( zeile[i].className.indexOf("showAlwaysIsTrue") > -1 ) ) {
+				zeile[i].style.display = ""
+				zeile[i].style.visibility = ""
+				// console.log(i+" "+txtValue) 
 			} 
 			// wenn Suchbegriff gefunden, dann CSS-display-Eigenschaft auf "none".
+			// aber CSS:visibility belassen für "addon_limit_results.js" usw.
 			else {
-				zeile[i].style.display = "none" 
+				zeile[i].style.display = "none"
+				zeile[i].style.visibility = "" 
 			} 
 		}
 	}

--- a/extras/addon_results_textfilter_by_button_parent-test.js
+++ b/extras/addon_results_textfilter_by_button_parent-test.js
@@ -1,0 +1,260 @@
+///////////////////////////////////////////////////////////////////////
+// DEFINITIONEN *** DEFINITIONS
+// http://www.mat-o-wahl.de
+
+// FUNKTION / FUNCTION
+// * Filtert Text in den Ergebnislisten anhand eines Zeichens / Zeichenkette.
+// Nützlich für mehrere Wahlen, z.B. Bürgermeister + Stadtrat
+ // * Filters text in the results based on a character or string.
+// Useful for multiple elections (Mayor + Council) 
+
+// 1.) Sonderzeichen oder Zeichenkette für die Filter (im Array) bestimmen
+// Define special character or string for filter (in an array)
+// Beispiel / example: U+1F464 (128100)	- BUST IN SILHOUETTE (Menschliche Silhouette)
+// https://de.wikipedia.org/wiki/Unicodeblock_Verschiedene_piktografische_Symbole
+// ODER unsichtbare Zeichen / OR invisible characters:
+// https://stackoverflow.com/questions/17978720/invisible-characters-ascii
+// U+200B    Zero-Width Space       &#8203;
+// U+200C    Zero Width Non-Joiner  &#8204;
+// U+200D    Zero Width Joiner      &#8205;
+// U+200E    Left-To-Right Mark     &#8206;
+// U+200F    Right-To-Left Mark     &#8207;
+var TEXTFILTER_KEYWORDS = ["&#8203;", "&#x1F464;", "&#8205;", "&#8206;", "#12345"]
+
+// 2.) Text für Buttons
+// Text on buttons
+var TEXTFILTER_BUTTONTEXTS = ["Alle anzeigen", "Bürgermeisterkandidaten &#x1F464; anzeigen", "Südfrüchte anzeigen", "Runde Früchte anzeigen", "12345"]
+
+
+// 3.) Filter-Sonderzeichen in PARTEIEN-ANTWORTEN.CSV einfügen. Beispiel:
+// Put the filter character(s) in PARTY-ANSWERS.CSV. Example:
+// Partei_Beschreibung:;"Die Apfelpartei steht seit vielen Jahren für alle Angelegenheiten des Apfels. &#x1F464; &#8203; &#8206;"
+// Partei_Beschreibung:;"Warum ist die Banane krumm? [...] alle Belange der Bananen.  &#8203; &#8205;"
+
+// 4.) In der DEFINITION.JS in den Erweiterten Einstellungen das Add-On eintragen.
+// Add the add-on to the advanced settings in DEFINITION.JS
+// var addons = ["extras/addon_results_textfilter_by_button.js"]
+
+// 5.) Fertig. 
+// That's it.
+
+
+///////////////////////////////////////////////////////////////////////  
+
+
+// Hier kommt nur noch Quellcode. Bitte gehen Sie weiter. Hier gibt es nichts zu sehen.
+// That's just source code. Please move on. Nothing to see here.
+
+
+///////////////////////////////////////////////////////////////////////
+
+
+// MutationObserver starten - prüft Änderungen im DOM
+// https://medium.com/better-programming/js-mutationobserver-1d7aed479da2
+// https://developer.mozilla.org/de/docs/Web/API/MutationObserver
+function mow_addon_textfilter_MutationObserver() {
+
+	// zu überwachende Zielnode (target) auswählen
+	var target = document.querySelector('#resultsHeading');
+	 
+	// eine Instanz des Observers erzeugen und Callback-Funktion aufrufen
+	var observer = new MutationObserver(mow_addon_textfilter_create_buttons)
+	 
+	// Konfiguration des Observers: alles melden - Änderungen an Daten, Kindelementen und Attributen
+	var config = { 
+		attributes: true, 
+		childList: true, 
+		subtree: true };
+	 
+	// eigentliche Observierung starten und Zielnode und Konfiguration übergeben
+	observer.observe(target, config);
+	 
+	// später: Observation wieder einstellen
+	// observer.disconnect();
+}
+
+
+// Buttons in Addon-DIV in INDEX.HTML schreiben
+function mow_addon_textfilter_create_buttons() {
+
+	// alten Inhalt (jedes Mal) löschen
+	$("#resultsAddonTop").empty()
+
+	// id "#resultsHeading" wird in fnStart() am Anfang geleert (empty()).
+	// -> mutationObserver erkennt Änderung und aktiviert diese Funktion :(
+	// -> prüfen, ob Inhalt in DIV existiert 
+	resultsHeadingContent = $("#resultsHeading").text()
+
+	if (!resultsHeadingContent) {
+		// nix. Noch keine Ergebnisse im DIV
+	}
+	// schreibe Buttons
+	else {
+		divContent = '<div class="row">'
+
+		// gehe durch Array und schreibe Inhalt
+		for (i = 0; i < TEXTFILTER_BUTTONTEXTS.length; i++) {
+			divContent += ' <div class="col">'
+			divContent += '  <button type="button" class="btn btn-secondary btn-block mow_addon_textfilter_button'+i+'" onclick="mow_addon_textfilter_filter_tables(\''+TEXTFILTER_KEYWORDS[i]+'\','+i+');">'+TEXTFILTER_BUTTONTEXTS[i]+'</button>'
+			divContent += ' </div>'
+		} // end: for TEXTFILTER_BUTTONTEXTS.length
+
+		divContent += '</div>'
+
+		// bis Version 0.6.0.2 - alleinige Anzeige der Buttons über der Überschrift :(
+		// $("#resultsAddonTop").append(divContent).fadeIn(750);
+		 
+		// Buttons OBEN anzeigen - UNTER der Überschrift und ÜBER der ersten Tabelle  
+		$( divContent ).insertBefore( $("#resultsShort") ).fadeIn(750);
+		
+		// Buttons UNTEN anzeigen - UNTER den ausführlichen Auswertungen und über der Fußzeile
+		$( divContent ).insertBefore( $("#sectionFooter") ).fadeIn(750); 
+
+		// ersten Button mit ID 0 aktivieren, so dass er gleich eingefärbt ist.
+		mow_addon_textfilter_color_buttons(0)
+
+	} // end: else
+
+}
+
+
+// Filter-Funktion
+// "search_keyword" und "status" kommen vom Button
+// Status = Suchbegriff anzeigen (1) oder ausblenden (0)
+function mow_addon_textfilter_filter_tables(search_keyword, idNumber) {
+	
+	// Button einfaerben
+	mow_addon_textfilter_color_buttons(idNumber)
+
+
+	var search_keyword = search_keyword.toUpperCase();
+
+	// obere Tabelle filtern - kurze Übersicht der Ergebnisse mit Prozentbalken
+	mow_addon_textfilter_hide_show_row(search_keyword, "resultsShortTable")
+	
+	// untere Tabelle 1 filtern - Ergebnisse sortiert nach Antworten
+	// Das Filter-Suchwort steht im TBODY mit der ID "resultsByThesisAnswersToQuestion"+j". 
+	// Die Frage steht in der Zeile darüber.
+	for (j = 0; j <= (intQuestions-1); j++) {
+		mow_addon_textfilter_hide_show_row(search_keyword, "resultsByThesisAnswersToQuestion"+j)
+	}
+
+	// untere Tabelle 2 filtern - Ergebnisse sortiert nach Parteien
+	// Schritt 1: in TBODY den ausgeblendeten Text finden
+	for (j = 0; j <= (intParties-1); j++) {
+		mow_addon_textfilter_hide_show_row(search_keyword, "resultsByPartyAnswersToQuestion"+j)
+	}
+
+	// untere Tabelle 2 filtern - Ergebnisse sortiert nach Parteien
+	// Schritt 2: in der Überschrift den ausgeblendeten Text finden
+	for (j = 0; j <= (intParties-1); j++) {
+		mow_addon_textfilter_hide_show_row(search_keyword, "resultsByPartyHeading"+j)
+	}
+
+}
+
+
+// die eigentliche Filter-Funktion
+// https://www.w3schools.com/howto/howto_js_filter_table.asp
+
+var stringRowNumbersTextfilter = ""
+var arrayRowNumbersTextfilter = []
+
+function mow_addon_textfilter_hide_show_row(search_keyword, tableID) {
+
+	// var stringRowNumbersTextfilter = ""
+	
+   table = document.getElementById(tableID);
+	zeile = table.getElementsByClassName("row")
+	
+
+
+	// Durch alle Zeilen gehen und diejenigen verstecken, ohne Suchbegriff.
+	for (i = 0; i < zeile.length; i++) {
+		{	
+
+			// console.log(i+" "+zeile[i].textContent)
+			txtValue = zeile[i].textContent || zeile[i].innerText;
+
+	
+			// Wenn Suchbegriff gefunden, dann CSS-display-Eigenschaft zurücksetzen. = anzeigen
+			// ... oder wenn CSS-(Pseudo)-Klasse "showAlwaysIsTrue" vorhanden ist = anzeigen (Buttons von addon_limit_results.js)
+			if ( (txtValue.toUpperCase().indexOf(search_keyword) > -1) || ( zeile[i].className.indexOf("showAlwaysIsTrue") > -1 ) ) {
+
+				// Ausnahme: #resultsShortTable -> Klammerzeile #resultsShortPartyClampX ohne Klasse ".row" abfangen
+				if (tableID == "resultsShortTable") {
+					zeile[i].parentElement.style.display = ""
+					zeile[i].parentElement.style.visibility = ""
+					console.log("* AN: "+i)	
+				} 
+				else {
+					zeile[i].style.display = ""
+					zeile[i].style.visibility = ""				
+				}
+				
+			
+				if (tableID.indexOf("resultsByThesisAnswersToQuestion0") > -1 ) {
+					// console.log(i+" "+txtValue) 
+					// console.log("Textfilter auf Tabelle "+tableID+" " +i)
+					stringRowNumbersTextfilter += i+","
+					arrayRowNumbersTextfilter.push(i)
+					fnTestVonTextfilter() // Aufruf einer Funktion aus dem anderen Addon
+
+				}
+				
+				
+			} 
+			// wenn Suchbegriff nicht gefunden, dann CSS-display-Eigenschaft auf "none".
+			// aber CSS:visibility belassen für "addon_limit_results.js" usw.
+			else {
+
+
+				// Ausnahme: #resultsShortTable -> Klammerzeile #resultsShortPartyClampX ohne Klasse ".row" abfangen
+				if (tableID == "resultsShortTable") { 
+					zeile[i].parentElement.style.display = "none"
+					zeile[i].parentElement.style.visibility = ""
+					// console.log("blende aus: "+zeile[i].textContent)
+					console.log("aus: "+i)	
+				}
+				else {
+					zeile[i].style.display = "none"
+					zeile[i].style.visibility = "" 
+				}
+
+
+			} 
+		}
+	}
+
+	// console.log("stringRowNumbersTextfilter: (Filter) "+stringRowNumbersTextfilter)
+	
+}
+
+
+// Den ausgewählten Button aktiv färben -> wird beim Klick auf Button aktiviert.
+function mow_addon_textfilter_color_buttons(idNumber) {
+
+	// Array 
+	for (i = 0; i < TEXTFILTER_BUTTONTEXTS.length; i++) {
+
+		if (i == idNumber)
+		{
+			$(".mow_addon_textfilter_button"+i).addClass('btn-primary').removeClass('btn-secondary');
+		}
+		else
+		{
+			$(".mow_addon_textfilter_button"+i).addClass('btn-secondary').removeClass('btn-primary');
+		}
+
+	} // end: for
+}
+
+
+// Start
+window.addEventListener("load", mow_addon_textfilter_MutationObserver)
+
+/*
+window.onload = function () {
+	mow_addon_textfilter_MutationObserver() 
+}
+*/

--- a/system/output.js
+++ b/system/output.js
@@ -375,58 +375,65 @@ function fnEvaluationShort(arResults)
 			var partyNum=arSortParties[i];
 			var percent = fnPercentage(arResults[partyNum],maxPoints)
 
-			tableContent += "<div class='row border rounded mow-row-striped' id='resultsShortParty"+partyNum+"' role='row'>"
-			// tableContent += "<tr id='resultsShortParty"+partyNum+"'>"
+			// "Klammer" um den Inhalt. 
+			// Wenn ein Addon (z.B. addon_contacts_in_results.js) eine neue Zeile unter die Zeile #resultsShortParty einfügt,
+			// bleiben die Zebrastreifen aus der Klasse ".mow-row-striped" in der richtigen Reihenfolge.
+			tableContent += "<div class='border rounded mow-row-striped' id='resultsShortPartyClamp"+partyNum+"' role='row'>"	
 
-				// Parteinamen: lang, kurz, Webseite, Beschreibung
-				tableContent += "<div class='col col-10 col-md-7' role='cell'>"
-				// tableContent += "<td style='width:60%;'>"
-
-//					tableContent += "<img src='"+arPartyLogosImg[partyNum]+"' class='rounded img-fluid float-right' alt='Logo "+arPartyNamesLong[partyNum]+"' style='margin-left: 10px; width:"+intPartyLogosImgWidth+"; height:"+intPartyLogosImgHeight+";' />"
-
-					tableContent += "<strong>"
-					tableContent += arPartyNamesLong[partyNum];
-					tableContent += "</strong>" 
-
-					tableContent += " (&#8663; <a href='"+arPartyInternet[partyNum]+"' target='_blank' alt='Link: "+arPartyNamesLong[partyNum]+"' title='Link: "+arPartyNamesLong[partyNum]+"'>";		
-					tableContent += arPartyNamesShort[partyNum];
-					tableContent += "</a>)";
-
-					// Beschreibung der Partei - falls in der CSV vorhanden.
-					// Nur die ersten 32 Zeichen anzeigen. 
-					// Danach abschneiden und automatisch ein/ausblenden (Funktionsaufbau weiter unten)
-					// Wenn keine Beschreibung gewünscht, dann "0" eintragen.
-					intPartyDescriptionPreview = 32
-					if ( (arPartyDescription[partyNum]) && (intPartyDescriptionPreview > 0) )
-					{
-						tableContent += "<p style='cursor: pointer;'> &bull; "
-						tableContent += arPartyDescription[partyNum].substr(0,intPartyDescriptionPreview)
-						tableContent += "<span id='resultsShortPartyDescriptionDots"+partyNum+"'>...</span>"
-						tableContent += "<span id='resultsShortPartyDescription"+partyNum+"'>"
-						tableContent += arPartyDescription[partyNum].substr(intPartyDescriptionPreview,1024)
-						tableContent += "</span> </p>"
-					}
-
-				tableContent += "</div>"
-				// tableContent += "</td>"
-
-				// Partei-Logo (automatisch angepasst)
-				tableContent += "<div class='col col-2 col-md-1' role='cell'>"
-				// tableContent += "<td>"
-					tableContent += "<img src='"+arPartyLogosImg[partyNum]+"' class='rounded img-fluid' alt='Logo "+arPartyNamesLong[partyNum]+"' />"
-				// tableContent += "</td>"
-				tableContent += "</div>"				
-
-				// Prozentwertung
-				tableContent += "<div class='col col-12 col-md-4' role='cell'>"
-				// tableContent += "<td style='width:40%;'>"
-					tableContent += "<div class='progress'>"
-					tableContent += "	<div class='progress-bar' role='progressbar' id='partyBar"+partyNum+"' style='width:"+percent+"%;' aria-valuenow='"+percent+"' aria-valuemin='0' aria-valuemax='100'>JUST_A_PLACEHOLDER_TEXT - SEE FUNCTION fnReEvaluate()</div> "
+				tableContent += "<div class='row' id='resultsShortParty"+partyNum+"' role='row'>"
+				// tableContent += "<tr id='resultsShortParty"+partyNum+"'>"
+	
+					// Parteinamen: lang, kurz, Webseite, Beschreibung
+					tableContent += "<div class='col col-10 col-md-7' role='cell'>"
+					// tableContent += "<td style='width:60%;'>"
+	
+	//					tableContent += "<img src='"+arPartyLogosImg[partyNum]+"' class='rounded img-fluid float-right' alt='Logo "+arPartyNamesLong[partyNum]+"' style='margin-left: 10px; width:"+intPartyLogosImgWidth+"; height:"+intPartyLogosImgHeight+";' />"
+	
+						tableContent += "<strong>"
+						tableContent += arPartyNamesLong[partyNum];
+						tableContent += "</strong>" 
+	
+						tableContent += " (&#8663; <a href='"+arPartyInternet[partyNum]+"' target='_blank' alt='Link: "+arPartyNamesLong[partyNum]+"' title='Link: "+arPartyNamesLong[partyNum]+"'>";		
+						tableContent += arPartyNamesShort[partyNum];
+						tableContent += "</a>)";
+	
+						// Beschreibung der Partei - falls in der CSV vorhanden.
+						// Nur die ersten 32 Zeichen anzeigen. 
+						// Danach abschneiden und automatisch ein/ausblenden (Funktionsaufbau weiter unten)
+						// Wenn keine Beschreibung gewünscht, dann "0" eintragen.
+						intPartyDescriptionPreview = 32
+						if ( (arPartyDescription[partyNum]) && (intPartyDescriptionPreview > 0) )
+						{
+							tableContent += "<p style='cursor: pointer;'> &bull; "
+							tableContent += arPartyDescription[partyNum].substr(0,intPartyDescriptionPreview)
+							tableContent += "<span id='resultsShortPartyDescriptionDots"+partyNum+"'>...</span>"
+							tableContent += "<span id='resultsShortPartyDescription"+partyNum+"'>"
+							tableContent += arPartyDescription[partyNum].substr(intPartyDescriptionPreview,1024)
+							tableContent += "</span> </p>"
+						}
+	
 					tableContent += "</div>"
-				tableContent += "</div>"
-				// tableContent += "</td>"
-
-			tableContent += "</div>" // end: row (for-i)
+					// tableContent += "</td>"
+	
+					// Partei-Logo (automatisch angepasst)
+					tableContent += "<div class='col col-2 col-md-1' role='cell'>"
+					// tableContent += "<td>"
+						tableContent += "<img src='"+arPartyLogosImg[partyNum]+"' class='rounded img-fluid' alt='Logo "+arPartyNamesLong[partyNum]+"' />"
+					// tableContent += "</td>"
+					tableContent += "</div>"				
+	
+					// Prozentwertung
+					tableContent += "<div class='col col-12 col-md-4' role='cell'>"
+					// tableContent += "<td style='width:40%;'>"
+						tableContent += "<div class='progress'>"
+						tableContent += "	<div class='progress-bar' role='progressbar' id='partyBar"+partyNum+"' style='width:"+percent+"%;' aria-valuenow='"+percent+"' aria-valuemin='0' aria-valuemax='100'>JUST_A_PLACEHOLDER_TEXT - SEE FUNCTION fnReEvaluate()</div> "
+						tableContent += "</div>"
+					tableContent += "</div>"
+					// tableContent += "</td>"
+	
+				tableContent += "</div>" // end: row #resultsShortPartyX
+			
+			tableContent += "</div>" // end: row .mow-row-striped + #resultsShortPartyClampX
 			// tableContent += "</tr>" 
 		
 		} // end for


### PR DESCRIPTION
* #70 - beim Ausklappen der Zusatzinformationen trotz Textfilter sollen die Antworten wieder zu sehen sein
* #68 - Partei-Antworten werden nicht mehr angezeigt, wenn die Partei gefiltert wird
* #65 - ein einfaches Addon für Kontaktanfragen (**Achtung**: Zu Testzwecken für den Textfilter noch mit einer zusätzlichen Zeile um zu sehen, ob der Textfilter auch mit 2 oder 3 oder 4 Zeilen klar kommt.)
* Das CSS für Links der `styles/default.css` wurde bereits im Main / Master angepasst, so dass `<a href>`-Links in `<button>`s nur noch die Bootstrap-Standardfarben nutzen. 