### PR TITLE
Issue 75 special characters in contacts addon

### DIFF
--- a/extras/addon_contacts_in_results.js
+++ b/extras/addon_contacts_in_results.js
@@ -97,7 +97,7 @@ function mow_addon_contacts_create_content() {
 			if (CONTACT_ACTIVE_EMAIL > 0 ) {	
 				
 				divContent += ' <div class="col">'
-				divContent += '  <a href="mailto:'+CONTACT_ADDRESS_EMAIL+'?subject='+encodeURI(CONTACT_SUBJECT_EMAIL)+''+arPartyNamesLong[partyNum]+'&body='+encodeURI(CONTACT_TEXT_EMAIL)+'_'+mow_addon_contacts_add_results_to_text()+'" role="button" class="btn btn-sm btn-success">'+CONTACT_BUTTON_EMAIL+'</a>'
+				divContent += '  <a href="mailto:'+CONTACT_ADDRESS_EMAIL+'?subject='+encodeURIComponent(CONTACT_SUBJECT_EMAIL)+''+encodeURIComponent(arPartyNamesLong[partyNum])+'&body='+encodeURIComponent(CONTACT_TEXT_EMAIL)+'_'+mow_addon_contacts_add_results_to_text()+'" role="button" class="btn btn-sm btn-success">'+CONTACT_BUTTON_EMAIL+'</a>'
 				divContent += ' </div>'
 			}
 
@@ -169,7 +169,7 @@ function mow_addon_contacts_add_results_to_text() {
 			statistics_text += "\n"+partyNameLong+": "+partyPoints+" Punkte";
 			
 		}
-		statistics_text = encodeURI(statistics_text);
+		statistics_text = encodeURIComponent(statistics_text);
 		return statistics_text;
 
 }

--- a/system/changelog.md
+++ b/system/changelog.md
@@ -21,6 +21,11 @@
 
 ## Versions:
 
+### 0.6.0.6.20221212
+
+- Minor fix
+  - Special characters in `extras/addon_contacts_in_results.js` were encoded with `encodeURI()` instead of `encodeURIComponent()`. Texts with ampersand (&) broke the email. https://github.com/msteudtn/Mat-O-Wahl/issues/75
+
 ### 0.6.0.5.20221106
 
 - Small fixes

--- a/system/general.js
+++ b/system/general.js
@@ -3,7 +3,7 @@
 // License: GPL 3
 // Mathias Steudtner http://www.medienvilla.com
 
-var version = "0.6.0.5.20221106"
+var version = "0.6.0.6.20221212"
 
 // Globale Variablen
 var arQuestionsShort = new Array();	// Kurzform der Fragen: Atomkraft, Flughafenausbau, ...


### PR DESCRIPTION
* Bugfix für https://github.com/msteudtn/Mat-O-Wahl/issues/75
* Kodierung im Addon berichtigt. ALT: `encodeURI()` NEU: encodeURIComponent()
* Beispiel-Erklärung: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI?retiredLocale=de#encodeuri_vs._encodeuricomponent