### PR TITLE
Fokus nach jedem Klick entfernen

### DIFF
--- a/system/output.js
+++ b/system/output.js
@@ -83,6 +83,11 @@ function fnStart()
 	$("#restart").attr("href","index.html?"+sekunden);
 	$("#restart").html(TEXT_RESTART);
 	
+	// Fokus nach jedem Klick entfernen
+	document.addEventListener("click", () => {
+          document.activeElement.blur()
+        }) 
+	
 	//////////////////////////////////////////////////////////////////
 	// FRAGEN UND ANTWORTEN in Arrays einlesen und Folgefunktionen aufrufen
 	// (a) Fragen 


### PR DESCRIPTION
...damit die Hervorhebung der Buttons nicht bleibt

Alternativ, damit das Event nicht nach jedem Klick überall im Dokument, sondern nur bei Buttons getriggert wird, ginge auch
```javascript
document.querySelectorAll("button").forEach(button => {
   button.addEventListener("click", () => {
          document.activeElement.blur()
     }) 
})
```
aber ich weiß nicht, ob das groß einen Unterschied macht.

Vermutlich gibt es dafür auch eine bessere Position im Code, mir ist nur auf die Schnelle nichts Besseres eingefallen.