### PR TITLE
intParties dynamisch berechnen

### DIFF
--- a/data/definition.js
+++ b/data/definition.js
@@ -96,11 +96,6 @@ const intQuestions = 6;
 
 const fileAnswers = "Obsthausen_Parteien.csv";
 
-
-// 	1.4 ANZAHL der PARTEIEN / 1.6 NUMBER of PARTIES
-
-const intParties = 4;
-
 /*
  	1.5. BILDGROESSE des PARTEILOGOS (am Ende)
 	DE: Die Breite und Höhe kann in Pixel und Prozent angegeben werden. 

--- a/system/general.js
+++ b/system/general.js
@@ -26,6 +26,28 @@ var arSortParties=new Array();		// Nummern der Listen, nach Punkten sortiert
 var activeQuestion=0; //aktuell angezeigte Frage (output.js)
 
 
+ // Zahl der Parteien dynamisch berechnen, anstatt sie in der definition.js anzugeben
+const intParties = () => {
+	$.ajax({ 
+	type: "GET", 
+	url: "data/"+fileAnswers,
+	dataType: "text", 
+	contentType: "application/x-www-form-urlencoded",
+		})
+	.done(data => {
+		let arIntParties = data.split("\n");
+		// Falls die fileAnswers (und damit der Array) mit leeren Zeilen endet, diese entfernen
+		while (true) {
+			if (arIntParties[arIntParties.length - 1] === "" || arIntParties[arIntParties.length - 1] === "\r") {
+				arIntParties.pop();
+			}
+			else break;
+		}
+		// Ergebnis runden, um Fehlertoleranz zu erhöhen
+		return Math.round(arIntParties.length / (intQuestions + 6));
+	})
+}
+
 // Einlesen der CSV-Datei und Weitergabe an Rückgabefunktion "fnCallback"
 function fnReadCsv(csvFile,fnCallback)
 {

--- a/system/general.js
+++ b/system/general.js
@@ -24,6 +24,7 @@ var arPartyLogosImg = new Array();		// Logos der Parteien
 var arSortParties=new Array();		// Nummern der Listen, nach Punkten sortiert
 
 var activeQuestion=0; //aktuell angezeigte Frage (output.js)
+let intParties = 0;
 
 // Einlesen der CSV-Datei und Weitergabe an Rückgabefunktion "fnCallback"
 function fnReadCsv(csvFile,fnCallback)
@@ -65,7 +66,7 @@ function fnReadCsv(csvFile,fnCallback)
 	}
 	// Globale Variable erstellen, um Problem mit return values in async ajax calls zu umgehen
 	// Ergebnis runden, um Fehlertoleranz zu erhöhen
-	window.intParties = Math.round(arIntParties.length / (intQuestions + 6));
+	return Math.round(arIntParties.length / (intQuestions + 6));
 }
 
 // Anzeige der Fragen (aus fnStart())
@@ -90,6 +91,7 @@ function fnReadPositions(csvData)
 {
 	// Einlesen der Parteipositionen und Vergleichen
 	// fnSplitLines(csvData,0);
+	intParties = fnSetIntParties(csvData)
 	fnTransformCsvToArray(csvData,0)
 }
 

--- a/system/general.js
+++ b/system/general.js
@@ -25,29 +25,6 @@ var arSortParties=new Array();		// Nummern der Listen, nach Punkten sortiert
 
 var activeQuestion=0; //aktuell angezeigte Frage (output.js)
 
-
- // Zahl der Parteien dynamisch berechnen, anstatt sie in der definition.js anzugeben
-const intParties = () => {
-	$.ajax({ 
-	type: "GET", 
-	url: "data/"+fileAnswers,
-	dataType: "text", 
-	contentType: "application/x-www-form-urlencoded",
-		})
-	.done(data => {
-		let arIntParties = data.split("\n");
-		// Falls die fileAnswers (und damit der Array) mit leeren Zeilen endet, diese entfernen
-		while (true) {
-			if (arIntParties[arIntParties.length - 1] === "" || arIntParties[arIntParties.length - 1] === "\r") {
-				arIntParties.pop();
-			}
-			else break;
-		}
-		// Ergebnis runden, um Fehlertoleranz zu erhöhen
-		return Math.round(arIntParties.length / (intQuestions + 6));
-	})
-}
-
 // Einlesen der CSV-Datei und Weitergabe an Rückgabefunktion "fnCallback"
 function fnReadCsv(csvFile,fnCallback)
 {
@@ -76,6 +53,20 @@ function fnReadCsv(csvFile,fnCallback)
 		});	
 }
 
+ // Zahl der Parteien dynamisch berechnen, anstatt sie in der definition.js anzugeben
+ function fnSetIntParties(data) {
+	let arIntParties = data.split("\n");
+	// Falls die fileAnswers (und damit der Array) mit leeren Zeilen endet, diese entfernen
+	while (true) {
+		if (arIntParties[arIntParties.length - 1] === "" || arIntParties[arIntParties.length - 1] === "\r") {
+			arIntParties.pop();
+		}
+		else break;
+	}
+	// Globale Variable erstellen, um Problem mit return values in async ajax calls zu umgehen
+	// Ergebnis runden, um Fehlertoleranz zu erhöhen
+	window.intParties = Math.round(arIntParties.length / (intQuestions + 6));
+}
 
 // Anzeige der Fragen (aus fnStart())
 function fnShowQuestions(csvData)

--- a/system/output.js
+++ b/system/output.js
@@ -84,6 +84,10 @@ function fnStart()
 	$("#restart").html(TEXT_RESTART);
 	
 	//////////////////////////////////////////////////////////////////
+	// Anzahl der Parteien berechnen
+	fnReadCsv("data/"+fileAnswers, fnSetIntParties)
+	const intParties = window.intParties
+	
 	// FRAGEN UND ANTWORTEN in Arrays einlesen und Folgefunktionen aufrufen
 	// (a) Fragen 
 	fnReadCsv("data/"+fileQuestions,fnShowQuestions)

--- a/system/output.js
+++ b/system/output.js
@@ -85,8 +85,8 @@ function fnStart()
 	
 	//////////////////////////////////////////////////////////////////
 	// Anzahl der Parteien berechnen
-	fnReadCsv("data/"+fileAnswers, fnSetIntParties)
-	const intParties = window.intParties
+//	fnReadCsv("data/"+fileAnswers, fnSetIntParties)
+//	const intParties = window.intParties
 	
 	// FRAGEN UND ANTWORTEN in Arrays einlesen und Folgefunktionen aufrufen
 	// (a) Fragen 


### PR DESCRIPTION
Anstatt die intParties nach jedem Update in der definition.js aktualisieren zu müssen, könnte diese auch dynamisch berechnet werden (aus der Länge der fileAnswers und der Zahl der Fragen).