### PR TITLE
Issue 53 html in fragen

### DIFF
--- a/data/Obsthausen_Fragen.csv
+++ b/data/Obsthausen_Fragen.csv
@@ -1,6 +1,6 @@
 "Farbe";"Die beste Fruchtfarbe ist gelb."
 "Form";"Die beste Fruchtform ist rund."
 "Schale";"Früchte muss man mit ihrer Schale essen können."
-"Spinat";"Spinat ist nicht nur gesund,  sondern schmeckt auch lecker."
-"Reife";"Früchte müssen bis zur vollen Reife an der Pflanze bleiben."
+"Spinat";"<a href='https://de.wikipedia.org/wiki/Spinat' target='_blank'>Spinat</a> ist nicht nur gesund, sondern schmeckt auch lecker."
+"Reife";"Früchte müssen bis zur <strong>vollen Reife</strong> an der Pflanze bleiben."
 "Süße";"Süße Früchte schmecken am besten."

--- a/data/Obsthausen_Fragen.csv
+++ b/data/Obsthausen_Fragen.csv
@@ -2,5 +2,5 @@
 "Form";"Die beste Fruchtform ist rund."
 "Schale";"Früchte muss man mit ihrer Schale essen können."
 "Spinat";"<a href='https://de.wikipedia.org/wiki/Spinat' target='_blank'>Spinat</a> ist nicht nur gesund, sondern schmeckt auch lecker."
-"Reife";"Früchte müssen bis zur <strong>vollen Reife</strong> an der Pflanze bleiben."
+"Reife";"Früchte müssen bis zur <span style='font-weight: 900;'>vollen Reife</span> an der Pflanze bleiben."
 "Süße";"Süße Früchte schmecken am besten."

--- a/styles/default.css
+++ b/styles/default.css
@@ -15,7 +15,7 @@ body {
 /* LINK-color - EXCEPT for Bootstrap button-class "btn". Use defaults there. */
 a:not(.btn) { color:#000000; text-decoration:underline;}
 a:not(.btn):link { color:#000000; } 
-a:not(.btn):visited { color:#808080; }
+a:not(.btn):visited { color:#404040; }
 a:not(.btn):active { color:#FF0000; }
 a:not(.btn):hover { color:#FF0000; text-decoration:none; }
 

--- a/system/changelog.md
+++ b/system/changelog.md
@@ -21,6 +21,10 @@
 
 ## Versions:
 
+### 0.6.0.10.20230420
+
+- Minor fix: The navigation-list (labeled "1-n") contains the short and long questions as title. If someone uses HTML-code inside the questions (see https://github.com/msteudtn/Mat-O-Wahl/issues/53) the navigation won't break now. Before, HTML-code wasn't filtered.
+
 ### 0.6.0.9.20230407
 
 - new addon `extras/addon_permalink_to_personal_result.js` to save a link of your result to the clipboard and come back to it later https://github.com/msteudtn/Mat-O-Wahl/pull/87 (Thanks to FEnglisch)

--- a/system/changelog.md
+++ b/system/changelog.md
@@ -23,7 +23,9 @@
 
 ### 0.6.0.10.20230420
 
-- Minor fix: The navigation-list (labeled "1-n") contains the short and long questions as title. If someone uses HTML-code inside the questions (see https://github.com/msteudtn/Mat-O-Wahl/issues/53) the navigation won't break now. Before, HTML-code wasn't filtered.
+- Minor fix: 
+  - The navigation-list (labeled "1-n") contains the short and long questions as title. If someone uses HTML-code inside the questions (see https://github.com/msteudtn/Mat-O-Wahl/issues/53) the navigation won't break now. Before, HTML-code wasn't filtered in `general/output.js`. Users can now **add links or text-formatting in their questions**.
+  - Visited links are now darker than before in `styles/default.css`
 
 ### 0.6.0.9.20230407
 

--- a/system/general.js
+++ b/system/general.js
@@ -3,7 +3,7 @@
 // License: GPL 3
 // Mathias Steudtner http://www.medienvilla.com
 
-var version = "0.6.0.9.20230407"
+var version = "0.6.0.10.20230420"
 
 // Globale Variablen
 var arQuestionsShort = new Array();	// Kurzform der Fragen: Atomkraft, Flughafenausbau, ...

--- a/system/output.js
+++ b/system/output.js
@@ -310,7 +310,9 @@ function fnJumpToQuestionNumber(questionNumber)
 		var modulo = i % questionsPerLine;
 		// neue Zeile
 		if (modulo == 1) { tableContent += "<tr>"; }
+		// Tabellenzelle mit kurzer und langer Frage (ohne HTML-Code = replace)
 		tableContent += "<td align='center' id='jumpToQuestionNr"+i+"' title='"+arQuestionsShort[(i-1)].replace( /(<([^>]+)>)/ig, '')+" - "+arQuestionsLong[(i-1)].replace( /(<([^>]+)>)/ig, '')+"'>"; 
+		// Nummer der Frage
 		tableContent += "<a href='javascript:fnShowQuestionNumber("+(i-2)+")' style='display:block;'>"+i+" </a>"; 
 		tableContent += "</td>";
 		if (modulo == 0) { tableContent += "</tr>"; }


### PR DESCRIPTION

- Minor fix: 
  - The navigation-list (labeled "1-n") contains the short and long questions as title. If someone uses HTML-code inside the questions (see https://github.com/msteudtn/Mat-O-Wahl/issues/53) the navigation won't break now. Before, HTML-code wasn't filtered in `general/output.js`. Users can now **add links or text-formatting in their questions**.
  - Visited links are now darker than before in `styles/default.css`